### PR TITLE
13.46% byte savings for modern browsers

### DIFF
--- a/README
+++ b/README
@@ -9,7 +9,7 @@ Usage:
 
 On modern browsers, you can inline it with a data URL:
 
-<script src="data:application/javascript,"></script>
+<script src="data:text/javascript,"></script>
 
 Alternatively, inline the whole code, like this:
 


### PR DESCRIPTION
Changed MIME-type to text/javascript (non-standard but faster) for inline data URI version - 13.46% byte savings for modern browsers.  Will research text/plain for additional 11% possible savings.