### PR TITLE
Convert to ECMAScript 6

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,6 +2,12 @@ module.exports = function(grunt) {
 
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
+    babel: {
+      dist: {
+        src: ['vapor.js'],
+        dest: 'vapor.js'
+      }
+    },
     concat: {
       options: {
         separator: ';'
@@ -26,13 +32,14 @@ module.exports = function(grunt) {
     }
   });
 
+  grunt.loadNpmTasks('grunt-babel');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-qunit');
   grunt.loadNpmTasks('grunt-contrib-concat');
 
   grunt.registerTask('test', ['jshint', 'qunit']);
-  grunt.registerTask('default', ['jshint', 'qunit', 'concat', 'uglify']);
-  grunt.registerTask('build', ['concat', 'uglify']);
+  grunt.registerTask('default', ['jshint', 'qunit', 'babel', 'concat', 'uglify']);
+  grunt.registerTask('build', ['babel', 'concat', 'uglify']);
 
 };

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "main": "./vapor",
     "devDependencies": {
       "grunt": "*",
+      "grunt-babel": "*",
       "grunt-contrib-jshint": "*",
       "grunt-contrib-uglify": "*",
       "grunt-contrib-concat": "*",


### PR DESCRIPTION
Converted vapor.js to ECMAScript 6 to keep with the current times and added Babel transpiling.
